### PR TITLE
Task#107519

### DIFF
--- a/pos_session_pay_invoice/__init__.py
+++ b/pos_session_pay_invoice/__init__.py
@@ -1,3 +1,3 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from . import wizard
+from . import models, wizard

--- a/pos_session_pay_invoice/models/__init__.py
+++ b/pos_session_pay_invoice/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order

--- a/pos_session_pay_invoice/models/pos_order.py
+++ b/pos_session_pay_invoice/models/pos_order.py
@@ -1,0 +1,19 @@
+from odoo import api, models
+from odoo.osv.expression import AND
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    @api.model
+    def search_paid_order_ids(self, config_id, domain, limit, offset):
+        with_ref_domain = [
+            ("pos_reference", "!=", False),
+        ]
+        new_domain = AND([domain, with_ref_domain])
+        return super(PosOrder, self).search_paid_order_ids(
+            config_id,
+            new_domain,
+            limit,
+            offset,
+        )


### PR DESCRIPTION
[FIX] `search_paid_order_ids` must exclude orders createds with this module

ver: https://github.com/OCA/pos/pull/1006